### PR TITLE
Remove 'commands' from API

### DIFF
--- a/src/action-select.ts
+++ b/src/action-select.ts
@@ -93,7 +93,6 @@ const entrySubmit = (entry?: Element) => {
 	}
 	chrome.runtime.sendMessage({
 		type: "invocation",
-		command: "",
 		key,
 		args: entrySubmitContextArgs,
 	}, response => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,7 +6,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 	switch (message.type) {
 	case "invocation": {
 		const action = getApiAction(message.key);
-		if (action && action.params && !Object.keys(action.params).every(param => message.args[param])) {
+		if (action && action.params && Object.keys(action.params).some(param => !message.args[param])) {
 			sendResponse({
 				context: {
 					paramInfo: Object.entries(action.params).find(([ param ]) => !message.args[param]),
@@ -14,7 +14,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 			});
 			return;
 		}
-		call(message.key, message.args, message.command);
+		call(message.key, message.args);
 		sendResponse({});
 		break;
 	} case "query": {


### PR DESCRIPTION
- Remove the concept of 'commands' (from Commander) and their handling, including expression evaluation